### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,18 @@ To run the example project, clone the repo, and run `pod install` from the Examp
 
 ## Requirements
 
-### Known Issues
-
-> 1. Developing on the new Arm-based Apple Silicon (M1) Macs requires building and running on a physical iOS device or using an iOS simulator running iOS 13.7, e.g. iPhone 11. This is a temporary limitation in Google Maps SDK for iOS, and as such also a limitation in MapsIndoors, due to the dependency to Google Maps.
-
 ## Installation
 
 MapsIndoors is available through [CocoaPods](http://cocoapods.org). To install it, add one of the following lines to your Podfile, depending on which map engine you will be using, Google Maps or Mapbox:
 
 To use the Google Maps map engine add
+
 ```ruby
 pod "MapsIndoorsGoogleMaps"
 ```
 
 To use the Mapbox map engine add
+
 ```ruby
 pod "MapsIndoorsMapbox"
 ```


### PR DESCRIPTION
Remove warning about Simulator when using Google Maps on Apple Silicon Macs